### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/benchmarks/web-search/server/docker-entrypoint.sh
+++ b/benchmarks/web-search/server/docker-entrypoint.sh
@@ -15,7 +15,7 @@ wget -O - $INDEX_URL \
   | tar zxvf - -C $SOLR_CORE_DIR/cloudsuite_web_search*
 
 echo "================================="
-echo "Index Node IP Address: "`ifconfig eth0 2>/dev/null|awk '/inet addr:/ {print $2}'|sed 's/addr://'`
+echo "Index Node IP Address: "`ifconfig eth0 2>/dev/null|awk '/inet addr:/ {print $2}'|sed 's/addr://'`"
 echo "================================="
   
 #Run Solr  


### PR DESCRIPTION
The ifconfig command isn't interpolated  properly due to the missing end quote, and thus not appearing in stdout. Since the directions on cloudsuite.ch clearly instruct end-users to look for this ip for use on in the client container, this causes substantial confusion (if not potentially other errors in the script..).  Please fix this issue :)  Thanks!